### PR TITLE
Added module support to slurm wrappers

### DIFF
--- a/src/main/groovy/bpipe/executor/SlurmCommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/SlurmCommandExecutor.groovy
@@ -46,6 +46,7 @@ import bpipe.Utils
  * 
  * @author simon.sadedin@mcri.edu.au
  * @author andrew.lonsdale@lonsbio.com.au
+ * @author slugger70@gmail.com
  */
 @Mixin(ForwardHost)
 @Log
@@ -72,6 +73,14 @@ class SlurmCommandExecutor extends TorqueCommandExecutor implements CommandExecu
             log.info "Using jobtype: $config?.jobtype"
             env.JOBTYPE = config.jobtype
         }
+
+        //modules since we may need to load modules before the command... - Simon Gladman (slugger70) 2014
+        if(config?.modules) {
+            log.info "Using modules: $config?.modules"
+            env.MODULES = config.modules
+        }
+
+
     }
 
     void cleanup() {


### PR DESCRIPTION
Hi Simon, this is a modification I made some time ago to allow me to add slurm modules in the bpipe config file under the commands section. An example is in the comments in the code. This saves me from having to load all the required modules on the command line before running my pipeline. This also allows me to use conflicting modules in different parts of the pipeline.

Cheers,

Simon Gladman
