### PR TITLE
save LSF output

### DIFF
--- a/src/main/groovy/bpipe/executor/LsfCommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/LsfCommandExecutor.groovy
@@ -72,6 +72,8 @@ class LsfCommandExecutor implements CommandExecutor {
 
     private static String CMD_OUT_FILENAME = "cmd.out"
 
+    private static String CMD_LSF_OUT_FILENAME = "cmd.lsf.out"
+
     private static String CMD_ERR_FILENAME = "cmd.err"
 
 	/**
@@ -141,7 +143,7 @@ class LsfCommandExecutor implements CommandExecutor {
 		 * Note: since LSF append a noise report information to the standard out
 		 * we suppress it, and save the 'cmd' output in the above script
 		 */
-		def startCmd = "bsub $cwdOption -o /dev/null -e $jobDir/$CMD_ERR_FILENAME "
+		def startCmd = "bsub $cwdOption -o $jobDir/$CMD_LSF_OUT_FILENAME -e $jobDir/$CMD_ERR_FILENAME "
         
 		// add other parameters (if any)
 		if(config?.queue) {


### PR DESCRIPTION
Hi guys,
I added a modification to save the LSF output into a file instead of discarding it to /dev/null. Like this, we can debug the frequent problem we have in our busy cluster, where tasks get easily killed because we're forced to be strict with the resources.

cheers,
Sergi