### PR TITLE
Do not hardcode the LSF shell that will run the job. New lsf_shell parameter for bpipe.config to choose the shell

### DIFF
--- a/src/main/groovy/bpipe/executor/LsfCommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/LsfCommandExecutor.groovy
@@ -103,10 +103,19 @@ class LsfCommandExecutor implements CommandExecutor {
         /*
          * Create 'cmd.sh' wrapper used by the 'bsub' command
          */
+        // If a shell is specified by the config then use that
+        def lsf_shell = "#!/bin/sh"
+        if(config?.lsf_shell) {
+            lsf_shell = config.lsf_shell
+            if(lsf_shell.take(2) != "#!") {
+                lsf_shell = "#!" + lsf_shell
+            }
+        }
+
         def cmdWrapperScript = new File(jobDir, CMD_SCRIPT_FILENAME)
         cmdWrapperScript.text =  
             """\
-            #!/bin/sh
+            $lsf_shell
             (${cmd}) > $jobDir/$CMD_OUT_FILENAME
             result=\$?
             echo -n \$result > $jobDir/$CMD_EXIT_FILENAME


### PR DESCRIPTION
With this modification, one can run jobs on different shells other than /bin/sh.

It's useful when one has shell scripts that are only compatible with other shells (csh, bash...). For example, this code is bash compatible but not sh, thus it requires the LsfExecutor to create the cmd.sh script with "#!/bin/bash" in the header:

```sh
bowtie -1 <(zcat $input1) -2 <(zcat $input2)
```

The modification will interpret the new **lsf_shell** variable in the bpipe.config file:

```java
executor="lsf"
queue="short"
commands {
    hello {
        lsf_shell="/bin/bash"
        walltime="0:05"
        procs=1
        lsf_request_options="-app Reserve300M -J Hello"
    }
    world {
        walltime="0:05"
        procs=4
        lsf_request_options="-app Reserve300M -J World"
    }
}
```

Which will create these cmd.sh files:

```sh
==> 1/cmd.sh <==
#!/bin/bash
(echo Hello) > .bpipe/commandtmp/1/cmd.out
result=$?
echo -n $result > .bpipe/commandtmp/1/cmd.exit
exit $result

==> 2/cmd.sh <==
#!/bin/sh
(echo World) > .bpipe/commandtmp/2/cmd.out
result=$?
echo -n $result > .bpipe/commandtmp/2/cmd.exit
exit $result
```