### PR TITLE
fix: Use LF line endings

### DIFF
--- a/test-src/bpipe/InputSplitterTest.groovy
+++ b/test-src/bpipe/InputSplitterTest.groovy
@@ -243,7 +243,8 @@ class InputSplitterTest {
         def matches = ("_foo_bar_" =~ pattern.pattern)
         assert matches[0][1] == "foo"
         assert matches[0][2] == "bar"
-	}	
+	}
+	
 
 	@Test
 	public void testNoStar() {
@@ -261,7 +262,8 @@ class InputSplitterTest {
         assert matches[0][1] == "cat"
         assert matches[0][2] == "foo"
         assert matches[0][3] == "bar"
-	}
+	}
+
 	@Test
 	public void testTwoStarTrailingUnderscore() {
         def pattern =  splitter.convertPattern("*_%_*_") 


### PR DESCRIPTION
Should fix below error in compileTestGroovy stage.

```text
General error during instruction selection: String index out of range: 68

java.lang.StringIndexOutOfBoundsException: String index out of range: 68
        at java.lang.String.substring(String.java:1963)
        at org.codehaus.groovy.runtime.powerassert.SourceText.<init>(SourceText.java:63)
        at org.codehaus.groovy.classgen.asm.AssertionWriter.writeAssertStatement(AssertionWriter.java:81)
        at org.codehaus.groovy.classgen.asm.StatementWriter.writeAssert(StatementWriter.java:578)
```
