### PR TITLE
feat: Generic message selector support in JMSAgent

### DIFF
--- a/src/main/groovy/bpipe/agent/JMSAgent.groovy
+++ b/src/main/groovy/bpipe/agent/JMSAgent.groovy
@@ -273,8 +273,15 @@ class JMSAgent extends Agent {
         this.session = connection.createSession(false,
              acknowledgeMode == 'read' ? Session.AUTO_ACKNOWLEDGE  : ActiveMQSession.INDIVIDUAL_ACKNOWLEDGE)
         this.queue = session.createQueue((String)config.commandQueue)
-        this.consumer = session.createConsumer(queue)
-        
+
+        if (config.containsKey('messageSelector')) {
+            log.info("Creating consumer for queue=${queue.queueName} with messageSelector=${config.messageSelector}")
+            this.consumer = session.createConsumer(queue, (String)config.messageSelector)
+        } else {
+            log.info("Creating consumer for queue=${queue.queueName}")
+            this.consumer = session.createConsumer(queue)
+        }
+
         log.info "Connected to ActiveMQ $config.commandQueue @ $config.brokerURL"
     }
 


### PR DESCRIPTION
E.g. config:

```groovy
agent {
  commandQueue='run_bpipe'
  ...
  messageSelector='user=\'lester.tester\''
}
```

References:

* https://activemq.apache.org/selectors.html
* https://camel.apache.org/components/3.20.x/eips/selective-consumer.html
* https://www.enterpriseintegrationpatterns.com/patterns/messaging/MessageSelector.html
