### PR TITLE
feat: Allow AMQ connection config to come from file

### DIFF
--- a/src/main/groovy/bpipe/Config.groovy
+++ b/src/main/groovy/bpipe/Config.groovy
@@ -114,6 +114,23 @@ class Config {
     public static List<String> listValue(String name) {
         return listValue(Config.userConfig, name)
     }
+    
+    @CompileStatic
+    static  <T> T  getOptionalUserConfigValue(List<String> path, T defaultValue) {
+
+        Object cfg = userConfig
+        
+        for(String key in path) {
+
+            if(!cfg.containsKey(key))
+                return defaultValue
+
+            if(cfg instanceof Map)
+                cfg = ((Map)cfg)[key]
+        }
+        
+        return cfg
+    }
 
     /**
      * Safely interrogate a configuration for an attribute and interpret as a list

--- a/src/main/groovy/bpipe/ForwardHost.groovy
+++ b/src/main/groovy/bpipe/ForwardHost.groovy
@@ -32,6 +32,7 @@ import java.nio.file.Path
 import java.util.List;
 import java.util.Timer;
 import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
 
 /**
  * A mixin that can be added to any class to add functions for it to forward 
@@ -39,8 +40,9 @@ import java.util.concurrent.TimeUnit
  * 
  * @author simon.sadedin
  */
-@Log
-class ForwardHost {
+trait ForwardHost {
+    
+    static Logger forwardLogger = Logger.getLogger("ForwardHost")
     
     transient List<Forwarder> forwarders = []
     
@@ -51,7 +53,7 @@ class ForwardHost {
     
     public void forward(Path file, def stream) {
         Forwarder f = new Forwarder(file, stream)
-        log.info "Forwarding path $file using forwarder $f"
+        forwardLogger.info "Forwarding path $file using forwarder $f"
         
         Poller.instance.executor.scheduleAtFixedRate(f, 0, 2000, TimeUnit.MILLISECONDS)
     
@@ -61,9 +63,9 @@ class ForwardHost {
     public void forward(String fileName, def stream) {
     
         Forwarder f = new Forwarder(new File(fileName), stream)
-        log.info "Forwarding file $fileName using forwarder $f"
+        forwardLogger.info "Forwarding file $fileName using forwarder $f"
         
-        Poller.instance.executor.scheduleAtFixedRate(f, 0, 2000, TimeUnit.MILLISECONDS)
+        Poller.theInstance.executor.scheduleAtFixedRate(f, 0, 2000, TimeUnit.MILLISECONDS)
     
         this.forwarders << f
     }
@@ -73,7 +75,7 @@ class ForwardHost {
      */
     @CompileStatic
     void stopForwarding() {
-        log.info "Cancelling and flushing outputs for forwarders: $forwarders"
+        forwardLogger.info "Cancelling and flushing outputs for forwarders: $forwarders"
         
         this.forwarders*.cancel()
         

--- a/src/main/groovy/bpipe/PipelineStage.groovy
+++ b/src/main/groovy/bpipe/PipelineStage.groovy
@@ -425,6 +425,13 @@ class PipelineStage {
                             
                     bindingVariables += resolvedExtras
                 }
+                
+                Map stageParameters = 
+                    Config.getOptionalUserConfigValue(['stages',stageName,'parameters'], (Map)null)
+
+                if(stageParameters) {
+                    bindingVariables.putAll(stageParameters)
+                }
                         
                 List returnedInputs 
                 Runner.binding.stageLocalVariables.set(bindingVariables)
@@ -659,6 +666,7 @@ class PipelineStage {
      * @TODO    remove this?
      */
     void copyContextBindingsToBody() {
+        
 		// Note: although it would appear these are being injected at a per-pipeline level,
 		// in fact they end up as globally shared variables across all parallel threads
 		// (there IS only ONE binding for a closure and only ONE closure instance getting 

--- a/src/main/groovy/bpipe/executor/AWSEC2CommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/AWSEC2CommandExecutor.groovy
@@ -281,10 +281,16 @@ class AWSEC2CommandExecutor extends CloudExecutor implements ForwardHost {
             if(Config.userConfig.containsKey('accessKey'))
                 config.accessKey = Config.userConfig.accessKey
             else
-                if(System.getenv('AWS_ACCESS_KEY_ID'))
-                    config.accessKey = System.getenv('AWS_ACCESS_KEY_ID')
-                else
-                    throw new Exception('AWSEC2 executor requires the accessKey configuration setting')
+            if(config.containsKey('profile')) {
+                Map keyInfo = bpipe.executor.AWSCredentials.theInstance.keys[config.profile]
+                config.accessKey = keyInfo.access_key_id
+                config.accessSecret = keyInfo.secret_access_key
+            }
+            else
+            if(System.getenv('AWS_ACCESS_KEY_ID'))
+                config.accessKey = System.getenv('AWS_ACCESS_KEY_ID')
+            else
+                throw new Exception('AWSEC2 executor requires the accessKey or profile configuration setting, or to have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables set')
         }
 
         if(!config.containsKey('accessSecret'))  {

--- a/src/main/groovy/bpipe/executor/AWSEC2CommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/AWSEC2CommandExecutor.groovy
@@ -445,7 +445,7 @@ class AWSEC2CommandExecutor extends CloudExecutor implements ForwardHost {
         
         List sshCommand = ["ssh","-oStrictHostKeyChecking=no", "-i", keypair, this.user + '@' + this.hostname,"bash"]
         
-        log.info "Lanching command saved in $cmdFile using: " + sshCommand.join(' ')
+        log.info "Launching command saved in $cmdFile using: " + sshCommand.join(' ')
         
         ExecutedProcess proc = Utils.executeCommand([:], sshCommand) {
             redirectInput(cmdFile)

--- a/src/main/groovy/bpipe/executor/AWSEC2CommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/AWSEC2CommandExecutor.groovy
@@ -69,8 +69,7 @@ import java.util.logging.Logger
  * An executor that runs commands by starting AWS EC2 images
  */
 @ToString(includeNames=true, excludes=['runningCommand','remoteErrorPath','exitFile'])
-@Mixin(ForwardHost)
-class AWSEC2CommandExecutor extends CloudExecutor {
+class AWSEC2CommandExecutor extends CloudExecutor implements ForwardHost {
     
     public static final long serialVersionUID = 0L
 
@@ -478,13 +477,7 @@ class AWSEC2CommandExecutor extends CloudExecutor {
     }
     
     @Override
-    public ExecutedProcess ssh(String cmd, Closure builder=null) {
-        ssh([:], cmd, builder)
-    }
- 
-
-    @Override
-    public ExecutedProcess ssh(Map options, String cmd, Closure builder=null) {
+    public ExecutedProcess ssh(Map options=[:], String cmd, Closure builder=null) {
         
         assert hostname != null && hostname != ""
         

--- a/src/main/groovy/bpipe/executor/CloudExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/CloudExecutor.groovy
@@ -243,8 +243,10 @@ abstract class CloudExecutor implements PersistentExecutor {
              return
              
         log.info("Command on $instanceId complete, transferring outputs $command.outputs back")
-        this.transferFrom(command.processedConfig, command.outputs)
-        this.transferredFrom = true
+        if(exitCode == 0) {
+            this.transferFrom(command.processedConfig, command.outputs)
+            this.transferredFrom = true
+        }
     }
     
     boolean canSSH() {

--- a/src/main/groovy/bpipe/executor/CloudExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/CloudExecutor.groovy
@@ -156,12 +156,15 @@ abstract class CloudExecutor implements PersistentExecutor {
      
     
     @Override
-    @CompileStatic
+//    @CompileStatic
     public int waitFor() {
         
         while(true) {
             CommandStatus status = this.status()
             if(status == CommandStatus.COMPLETE) { 
+                
+                this.stopForwarding()
+
                 return exitCode
             }
                 

--- a/src/main/groovy/bpipe/executor/GoogleCloudCommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/GoogleCloudCommandExecutor.groovy
@@ -44,8 +44,7 @@ import groovy.util.logging.Log
  * @author simon.sadedin
  */
 @Log
-@Mixin(ForwardHost)
-class GoogleCloudCommandExecutor extends CloudExecutor {
+class GoogleCloudCommandExecutor extends CloudExecutor implements ForwardHost {
     
     public static final long serialVersionUID = 0L
     
@@ -188,7 +187,7 @@ class GoogleCloudCommandExecutor extends CloudExecutor {
             
     }
 
-    ExecutedProcess ssh(Map options, String cmd, Closure builder=null) {
+    ExecutedProcess ssh(Map options=[:], String cmd, Closure builder=null) {
         
         String sdkHome = getSDKHome()
         

--- a/src/main/groovy/bpipe/executor/LocalCommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/LocalCommandExecutor.groovy
@@ -48,8 +48,7 @@ import bpipe.CommandManager;
  * @author simon.sadedin@mcri.edu.au
  */
 @Log
-@Mixin(ForwardHost)
-class LocalCommandExecutor implements CommandExecutor {
+class LocalCommandExecutor implements CommandExecutor, ForwardHost {
     
     public static final long serialVersionUID = 0L
     

--- a/src/main/groovy/bpipe/executor/SgeCommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/SgeCommandExecutor.groovy
@@ -44,9 +44,8 @@ import bpipe.ExecutedProcess
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-@Mixin(ForwardHost)
 @Log
-class SgeCommandExecutor implements CommandExecutor {
+class SgeCommandExecutor implements CommandExecutor, ForwardHost {
     
     public static final long serialVersionUID = 520230130470104528L;
 

--- a/src/main/groovy/bpipe/executor/SlurmCommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/SlurmCommandExecutor.groovy
@@ -48,7 +48,6 @@ import bpipe.Utils
  * @author andrew.lonsdale@lonsbio.com.au
  * @author slugger70@gmail.com
  */
-@Mixin(ForwardHost)
 @Log
 class SlurmCommandExecutor extends TorqueCommandExecutor implements CommandExecutor {
 

--- a/src/main/groovy/bpipe/executor/TorqueCommandExecutor.groovy
+++ b/src/main/groovy/bpipe/executor/TorqueCommandExecutor.groovy
@@ -44,7 +44,6 @@ import bpipe.Utils
  * 
  * @author simon.sadedin@mcri.edu.au
  */
-@Mixin(ForwardHost)
 @Log
 class TorqueCommandExecutor extends CustomCommandExecutor implements CommandExecutor {
 

--- a/src/main/groovy/bpipe/notification/ActivemqNotificationChannel.groovy
+++ b/src/main/groovy/bpipe/notification/ActivemqNotificationChannel.groovy
@@ -1,5 +1,7 @@
 package bpipe.notification
 
+import groovy.json.JsonException
+import groovy.json.JsonSlurper
 import org.apache.activemq.ActiveMQConnection
 
 import org.apache.activemq.ActiveMQConnectionFactory
@@ -10,6 +12,10 @@ import groovy.util.logging.Log
 import groovy.json.JsonOutput
 import groovy.text.Template
 
+import java.nio.file.Files
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.Map
 import javax.jms.Connection
 import javax.jms.MessageProducer
@@ -57,7 +63,10 @@ class ActivemqNotificationChannel extends JMSNotificationChannel {
             
            
         def connectionFactory = new ActiveMQConnectionFactory(brokerURL: config.brokerURL)
-        
+
+        if (config.containsKey('username') && config.containsKey('credentialsJsonFile')) {
+            throw new PipelineError("ActiveMQ configuration username and credentialsJsonFile are mutually exclusive, please only provide one or the other")
+        }
         if(config.containsKey('username')) {
             if(!(config.containsKey('password')))
                 throw new PipelineError("ActiveMQ configuration is missing required key 'password'")
@@ -71,6 +80,54 @@ class ActivemqNotificationChannel extends JMSNotificationChannel {
 
             log.info "Configured ActiveMQ using usernmae $config.username"
             return connectionFactory.createConnection(config.username, config.password)
+        }
+        else if (config.containsKey('credentialsJsonFile')) {
+
+            /**
+             * If optional credentialsJsonKeyMapping is provided, then use that to get the json property values,
+             * otherwise, assume the file contains username and password properties.
+             *
+             * Expected json format of credentialsJsonFile:
+             * {
+             *     "username": username,
+             *     "password": secret
+             * }
+             *
+             * or if credentialsJsonKeyMapping is provided:
+             * {
+             *     "client_id": oidc-client-id,
+             *     "id_token": oidc-id-token
+             * }
+             *
+             * where credentialsJsonKeyMapping is:
+             * {
+             *    "username": "client_id",
+             *    "password": "id_token"
+             * }
+             */
+            try {
+                Path filePath = Paths.get(config.credentialsJsonFile as String)
+                if (!Files.exists(filePath)) {
+                    throw new PipelineError("ActiveMQ configuration credentialsJsonFile does not exist: ${config.credentialsJsonFile}")
+                }
+                log.info("Using ActiveMQ credentialsJsonFile: ${config.credentialsJsonFile}")
+                String fileContents = filePath.toFile().text
+                def credentialsJson = new JsonSlurper().parseText(fileContents)
+                String usernameKey = config.credentialsJsonKeyMapping?.username ?: "username"
+                String passwordKey = config.credentialsJsonKeyMapping?.password ?: "password"
+                log.info("Using usernameKey=$usernameKey and passwordKey=$passwordKey from credentials file for lookup")
+                String username = credentialsJson."$usernameKey"
+                String password = credentialsJson."$passwordKey"
+
+                if (username && password) {
+                    return connectionFactory.createConnection(username, password)
+                } else {
+                    throw new PipelineError("ActiveMQ configuration using ${config.credentialsJsonFile} has missing username and/or password")
+                }
+            }
+            catch (InvalidPathException | JsonException | IOException e) {
+                throw new PipelineError("ActiveMQ configuration using ${config.credentialsJsonFile} is not valid, ${e.message}")
+            }
         }
         else {
             log.info "Configured ActiveMQ without username / password"

--- a/tests/stage_specific_parameter/bpipe.config
+++ b/tests/stage_specific_parameter/bpipe.config
@@ -1,0 +1,20 @@
+parameters {
+    foo="ooogiee"
+}
+
+stages {
+    hello {
+        parameters {
+            foo="gotcha"
+        }
+    }
+}
+
+environments {
+   bingo {
+      stages {
+          hello.parameters.foo = "yayyy!"
+      }
+   }
+}
+

--- a/tests/stage_specific_parameter/run.sh
+++ b/tests/stage_specific_parameter/run.sh
@@ -1,0 +1,13 @@
+source ../testsupport.sh
+
+run
+
+grep -q "Foo = gotcha" test.out || err "Did not observe expected default env value of foo=gotcha"
+
+grep -q "Default Foo = ooogiee" test.out || err "Did not observe expected default value of foo=ooogiee"
+
+bpipe run --env bingo test.groovy > test.out 
+
+grep -q "Default Foo = ooogiee" test.out || err "Did not observe expected default value of foo=ooogiee"
+
+grep -q "Foo = yayyy" test.out || err "Did not observe expected environment specific value of foo=yayyy"

--- a/tests/stage_specific_parameter/test.groovy
+++ b/tests/stage_specific_parameter/test.groovy
@@ -1,0 +1,18 @@
+
+println "Global foo = $foo"
+
+hello = {
+    exec """
+       echo "Foo = $foo"
+    """
+}
+
+world = {
+    exec """
+        echo "Default Foo = $foo"
+    """
+}
+
+run {
+    hello + world
+}


### PR DESCRIPTION
This allows credentials to be given from a credentials json file.  Optional config map to determine which json key is username and password json file can be provided.  I needed this to ensure bpipe agent always uses latest credentials from a file.
