### PR TITLE
feat: Add new execOptions for Singularity container config

### DIFF
--- a/src/main/groovy/bpipe/processors/SingularityContainerWrapper.groovy
+++ b/src/main/groovy/bpipe/processors/SingularityContainerWrapper.groovy
@@ -66,11 +66,13 @@ class SingularityContainerWrapper implements CommandProcessor {
         log.info "Resolved singularity image $config.image for command $command.id at $imagePath"
         
         String shell = config.getOrDefault('shell', '/bin/bash')
+
+        String execOptions = config.execOptions ?: ''
         
         command.shell = 
             [
                 "singularity",
-                "exec",
+                "exec", execOptions,
                 "-B", Runner.runDirectory,
                 "--pwd", bpipe.Runner.runDirectory,
             ] + extraVolumes + [imagePath, shell, '-e']

--- a/test-src/bpipe/SingularityContainerTest.groovy
+++ b/test-src/bpipe/SingularityContainerTest.groovy
@@ -20,9 +20,10 @@ class SingularityContainerTest {
     Map config = [
         container: [ 
             type:'singularity', 
-            image:'my_test_image'
-            ] 
+            image:'my_test_image',
+            execOptions: '--nv'
         ]
+    ]
         
     @Before
     void setup() {
@@ -37,6 +38,8 @@ class SingularityContainerTest {
         
         assert command.shell[0] == 'singularity'
         assert command.shell.findIndexOf { it == '-B' }  > 0
+        def execIndex = command.shell.findIndexOf { it == 'exec' }
+        assert command.shell[execIndex+1] == '--nv'
         assert command.shell[-3].path == 'my_test_image'
     }
 
@@ -52,6 +55,8 @@ class SingularityContainerTest {
         
         assert command.shell[0] == 'singularity'
         assert command.shell.findIndexOf { it == '-B' }  > 0
+        def execIndex = command.shell.findIndexOf { it == 'exec' }
+        assert command.shell[execIndex+1] == '--nv'
         assert command.shell[-3].path == 'my_test_image'
         
         def binds = command.shell.findIndexValues { it == '-B' }.collect { command.shell[it+1] }


### PR DESCRIPTION
This is required for passing in the `--nv` option so Nvidia GPUs can be recognised in the Singularity container.
