### PR TITLE
fix: bpipe.$LAUNCHER_PID.run.pid race condition

### DIFF
--- a/bin/bpipe
+++ b/bin/bpipe
@@ -749,7 +749,13 @@ fi
 set +f
 
 tmsg " Waiting for pid to be created"
-while [ ! -e .bpipe.$LAUNCHER_PID.run.pid ];
+
+# this checks:
+#  - whether the file .bpipe.$LAUNCHER_PID.run.pid either does not exist OR does exist and is not empty
+#  - and also validates that the PID is in fact a multi-digit string
+# in response to https://github.com/ssadedin/bpipe/issues/201 and https://github.com/ssadedin/bpipe/issues/290.
+while [ ! -s .bpipe.$LAUNCHER_PID.run.pid ] || \
+	! [[ $(cat .bpipe.$LAUNCHER_PID.run.pid) =~ ^[0-9]+$ ]];
 do
   if type usleep > /dev/null 2>&1 ;
   then


### PR DESCRIPTION
This addresses #201 and #290. A race condition is created when waiting for `.bpipe.$LAUNCHER_PID.run.pid` to be created and written to, when it is possible to read the value of the file after it has been created but *before* it is populated. This results in an empty `$BPIPE_PID` and the script errors.

While theoretically possible on bare metal, it seems like this issue is more likely to occur when using a container. Reports have indicated that it occurs sometimes on both Docker and Apptainer runtimes, potentially due to different filesystem manipulation mechanics. (My very rough testing with v0.9.9.2 had this bug occur 7.8% of the time in 180 runs, through Apptainer).

This change adds more thorough validation of this file to ensure that it is populated, by using the `-s` flag instead of `-e` to check a file exists and is not empty. It also uses a regex string to ensure that the PID is a integer value, just in case. In theory, the PID string is so small that it should be updated to the file in a single write, so it *should* be true that "file exists AND is not empty" is a sufficient condition.

I have a more detailed writeup of the conditions causing the issue [here](https://github.com/ssadedin/bpipe/issues/290#issuecomment-2284086652).